### PR TITLE
miscellaneous OneWire low level improvements

### DIFF
--- a/ds18b20.h
+++ b/ds18b20.h
@@ -4,8 +4,8 @@
 //	2018/09/08
 
 
-#include "onewire.h"
 #include "ds18b20Config.h"
+#include "onewire.h"
 #include <stdbool.h>
 
 #if (_DS18B20_USE_FREERTOS==1)
@@ -51,6 +51,8 @@ extern Ds18b20Sensor_t	ds18b20[_DS18B20_MAX_SENSORS];
 #define DS18B20_DATA_LEN							2
 #endif
 
+//extern OneWire_t;
+
 //###################################################################################
 typedef enum {
 	DS18B20_Resolution_9bits = 9,   /*!< DS18B20 9 bits resolution */
@@ -66,10 +68,20 @@ void			Ds18b20_Init(osPriority Priority);
 bool			Ds18b20_Init(void);
 #endif
 bool			Ds18b20_ManualConvert(void);
+//struct OneWire_t;
 //###################################################################################
 uint8_t 	DS18B20_Start(OneWire_t* OneWireStruct, uint8_t* ROM);
-void 			DS18B20_StartAll(OneWire_t* OneWireStruct);
-bool		 	DS18B20_Read(OneWire_t* OneWireStruct, uint8_t* ROM, float* destination);
+/**
+ * \brief send start temperature conversion command to all devices on the bus
+ * \return false if no devices on the bus, otherwise true
+ */
+bool 		DS18B20_StartAll(OneWire_t* OneWireStruct);
+/**
+ * \brief read temperature from device with address ROM or the single device
+ * \param [in] ROM address of the selected device or 0 if the only one device on the bus
+ * \return true if reading OK
+ */
+bool		DS18B20_Read(OneWire_t* OneWireStruct, uint8_t* ROM, float* destination);
 uint8_t 	DS18B20_GetResolution(OneWire_t* OneWireStruct, uint8_t* ROM);
 uint8_t 	DS18B20_SetResolution(OneWire_t* OneWireStruct, uint8_t* ROM, DS18B20_Resolution_t resolution);
 uint8_t 	DS18B20_Is(uint8_t* ROM);

--- a/ds18b20Config.h
+++ b/ds18b20Config.h
@@ -9,13 +9,20 @@
 #define	_DS18B20_GPIO												DS18B20_GPIO_Port
 #define	_DS18B20_PIN												DS18B20_Pin
 
-#define	_DS18B20_CONVERT_TIMEOUT_MS					5000		
+#define	_DS18B20_CONVERT_TIMEOUT_MS					5000
 #if (_DS18B20_USE_FREERTOS==1)
-#define	_DS18B20_UPDATE_INTERVAL_MS					10000					//  (((	if==0  >> Ds18b20_ManualConvert()  )))    ((( if>0  >>>> Auto refresh ))) 
+#define	_DS18B20_UPDATE_INTERVAL_MS					10000					//  (((	if==0  >> Ds18b20_ManualConvert()  )))    ((( if>0  >>>> Auto refresh )))
 #endif
 
+#define	_DS18B20_TIMER											htim13
+#define _DS18B20_NO_NOT_USE_TIMER						1	/// use NOPs instead of hardware timer
 
-#define	_DS18B20_TIMER											htim13						
+#ifdef DEBUG
+#define _DS18B20_CYCS_PER_NS							250	/// for(){NOP} cycles per nanosecond for 72 MHz core clock
+#else
+#define _DS18B20_CYCS_PER_NS							150	/// for(){NOP} cycles per nanosecond for 72 MHz core clock
+#endif
+
 //###################################################################################
 
 #endif

--- a/onewire.h
+++ b/onewire.h
@@ -30,9 +30,10 @@ void ONEWIRE_DELAY(uint16_t time_us);
 
 /* Pin settings */
 void ONEWIRE_LOW(OneWire_t *gp);			
-void ONEWIRE_HIGH(OneWire_t *gp);		
+void ONEWIRE_HIGH(OneWire_t *gp);
 void ONEWIRE_INPUT(OneWire_t *gp);		
 void ONEWIRE_OUTPUT(OneWire_t *gp);		
+void ONEWIRE_OUTPUT_PP(OneWire_t *gp);	///< set OneWire pin to the output push-pull mode, use this for powering for conversion
 
 /* OneWire commands */
 #define ONEWIRE_CMD_RSCRATCHPAD			0xBE


### PR DESCRIPTION
 * option for delaying with NOPs instead of using a timer
 * removed unnecessary long commands in time-critical parts
 * added critical sections in time-critical parts, it is mandatory
 * added command for supply for power heavy operation, such as measuring at high temperature
 * added reading single device on the bus without selecting by ROM